### PR TITLE
feat(event-no-renditions): schema denies events with renditions

### DIFF
--- a/specification/ninjs-schema_2.2.json
+++ b/specification/ninjs-schema_2.2.json
@@ -1325,7 +1325,12 @@
   "then": {
     "required": [
       "eventdetails"
-    ]
+    ],
+    "not": {
+      "required": [
+        "renditions"
+      ]
+    }
   },
   "unevaluatedProperties": false
 }

--- a/validation/test_suite/2.2/should_fail/004_event_with_renditions.json
+++ b/validation/test_suite/2.2/should_fail/004_event_with_renditions.json
@@ -1,0 +1,33 @@
+{
+  "standard": {
+    "name": "ninjs",
+    "version": "2.2",
+    "schema": "http://www.iptc.org/std/ninjs/ninjs-schema_2.2.json"
+  },
+  "uri": "urn:nato.int:2023-nato-summit-press-conference",
+  "type": "event",
+  "title": "2023 NATO Summit Press Conference",
+  "eventdetails": {
+    "dates": {
+      "startdate": "2023-07-11T09:00:00Z",
+      "expectedstartdate": "2023-07-12"
+    }
+  },
+  "places": [
+    {
+      "name": "LITEXPO",
+      "contactinfo": [
+        {
+          "type": "physical",
+          "address": {
+            "locality": "Vilnius",
+            "country": "Lithuania"
+          }
+        }
+      ]
+    }
+  ],
+  "renditions": [
+
+  ]
+}


### PR DESCRIPTION
addresses an unintended use of events observed at the dpp lpx hackathon. Another option to discuss, there may be other aspects of the schema we don't intend people to use within the planning or event types but this was scoped specifically to the behaviour seen where users used a mixture of item level, planning and event level metadata in one document of type event.