### PR TITLE
feat(news-item-planned): add test example planned coverage

### DIFF
--- a/validation/test_suite/2.2/should_pass/010_planned_news_item.json
+++ b/validation/test_suite/2.2/should_pass/010_planned_news_item.json
@@ -14,7 +14,8 @@
   "associations": [
     {
       "uri": "urn:005-ninjs2.2-planned-coverage-test",
-      "name": "Planned coverage"
+      "name": "Planned coverage",
+      "type": "planning"
     }
   ]
 }


### PR DESCRIPTION
links from news item to the planned coverage via associations