### PR TITLE
feat(restrict-planning): avoid planning documents having event details or renditions

### DIFF
--- a/specification/ninjs-schema_2.2.json
+++ b/specification/ninjs-schema_2.2.json
@@ -1356,25 +1356,62 @@
   "required": [
     "uri"
   ],
-  "if": {
-    "properties": {
-      "type": {
-        "const": "event"
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "event"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "required": [
+          "eventdetails"
+        ],
+        "not": {
+          "required": [
+            "renditions"
+          ]
+        }
       }
     },
-    "required": [
-      "type"
-    ]
-  },
-  "then": {
-    "required": [
-      "eventdetails"
-    ],
-    "not": {
-      "required": [
-        "renditions"
-      ]
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "planning"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "allOf": [
+          {
+            "required": [
+              "plannedcoverage"
+            ],
+            "not": {
+              "required": [
+                "renditions"
+              ]
+            }
+          },
+          {
+            "not": {
+              "required": [
+                "eventdetails"
+              ]
+            }
+          }
+        ]
+      }
     }
-  },
+  ],
   "unevaluatedProperties": false
 }

--- a/validation/test_suite/2.2/should_fail/005_planning_toplevel_renditions.json
+++ b/validation/test_suite/2.2/should_fail/005_planning_toplevel_renditions.json
@@ -1,0 +1,51 @@
+{
+  "standard": {
+    "name": "ninjs",
+    "version": "2.2",
+    "schema": "http://www.iptc.org/std/ninjs/ninjs-schema_2.2.json"
+  },
+  "uri": "urn:nato.int:2023-nato-summit-press-conference",
+  "type": "planning",
+  "title": "Planned coverage of the 2023 NATO Summit Press Conference",
+  "plannedcoverage": [
+    {
+      "uri": "planning-times-square-001-text",
+      "title": "Text article covering the NATO Summit Press Conference",
+      "type": "text",
+      "event": "urn:004-ninjs2.2-recurring-event-test",
+      "itemcount": { "rangefrom": 1, "rangeto": 1 },
+      "scheduled": "2024-01-01T00:30:00-04:00",
+      "services": [
+        "all-items-feed",
+        "all-text-items-feed",
+        "text-highlights-feed"
+      ],
+      "wordcount": 300,
+      "language": "en-US",
+      "audiences": [
+        {
+          "audience": "45-60",
+          "significance": 8
+        }
+      ],
+      "renditions": [
+      ]
+    }
+  ],
+  "places": [
+    {
+      "name": "LITEXPO",
+      "contactinfo": [
+        {
+          "type": "physical",
+          "address": {
+            "locality": "Vilnius",
+            "country": "Lithuania"
+          }
+        }
+      ]
+    }
+  ],
+  "renditions": [
+  ]
+}

--- a/validation/test_suite/2.2/should_fail/006_planning_with_eventdetails.json
+++ b/validation/test_suite/2.2/should_fail/006_planning_with_eventdetails.json
@@ -1,0 +1,59 @@
+{
+  "standard": {
+    "name": "ninjs",
+    "version": "2.2",
+    "schema": "http://www.iptc.org/std/ninjs/ninjs-schema_2.2.json"
+  },
+  "uri": "urn:nato.int:2023-nato-summit-press-conference",
+  "type": "planning",
+  "title": "2023 NATO Summit Press Conference",
+  "plannedcoverage": [
+    {
+      "uri": "planning-times-square-001-text",
+      "title": "Text article covering the NATO Summit Press Conference",
+      "type": "text",
+      "event": "urn:004-ninjs2.2-recurring-event-test",
+      "itemcount": { "rangefrom": 1, "rangeto": 1 },
+      "scheduled": "2024-01-01T00:30:00-04:00",
+      "services": [
+        "all-items-feed",
+        "all-text-items-feed",
+        "text-highlights-feed"
+      ],
+      "wordcount": 300,
+      "language": "en-US",
+      "audiences": [
+        {
+          "audience": "45-60",
+          "significance": 8
+        }
+      ],
+      "renditions": [
+      ]
+    }
+  ],
+  "eventdetails": {
+    "dates": {
+      "startdate": "2023-07-11T09:00:00Z",
+      "enddate": "2023-07-12T17:00:00Z"
+    },
+    "organiser": {
+      "name": "NATO",
+      "uri": "https://www.nato.int/"
+    }
+  },
+  "places": [
+    {
+      "name": "LITEXPO",
+      "contactinfo": [
+        {
+          "type": "physical",
+          "address": {
+            "locality": "Vilnius",
+            "country": "Lithuania"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is an option around restricting the planning documents so they don't end up carrying event details or renditions. we might want to look at defining top level types for each as an alternative and see if we can have an anyOf within ninjsType for planningType eventType and itemType.

I think the type based approach could be cleaner but the schema will be possibly more verbose, albeit they can gain a lot of their definition through shared types.