### PR TITLE
fix(event-restrictions): relax use of schema

### DIFF
--- a/specification/ninjs-schema_3.0.json
+++ b/specification/ninjs-schema_3.0.json
@@ -1366,25 +1366,5 @@
   "required": [
     "uri"
   ],
-  "if": {
-    "properties": {
-      "type": {
-        "const": "event"
-      }
-    },
-    "required": [
-      "type"
-    ]
-  },
-  "then": {
-    "required": [
-      "eventDetails"
-    ],
-    "not": {
-      "required": [
-        "renditions"
-      ]
-    }
-  },
   "unevaluatedProperties": false
 }


### PR DESCRIPTION
To allow for rush events with inline media remove the blocking of renditions on event documents